### PR TITLE
add simple input validation to CollectBaseURL

### DIFF
--- a/condeco-cli/InteractiveSession.cs
+++ b/condeco-cli/InteractiveSession.cs
@@ -29,8 +29,20 @@ namespace condeco_cli
 
         void CollectBaseUrl()
         {
-            Collect(ref config.Account.BaseUrl, "Please enter the url of your Condeco service (example: https://acme.condecosoftware.com): ");
-            config.Save();
+            while (true)
+            {
+                Collect(ref config.Account.BaseUrl, "Please enter the url of your Condeco service (example: https://acme.condecosoftware.com): ");
+
+                if (Uri.TryCreate(config.Account.BaseUrl, UriKind.Absolute, out var _))
+                {
+                    config.Save();
+                    return;
+                }
+                else
+                {
+                   AnsiConsole.MarkupLine("[red]The URL entered is not valid. Please try again.[/]\n");
+                }
+            } 
         }
 
         void CollectCreds()


### PR DESCRIPTION
During parsing of the BaseURL from the config and after an invalid URL is entered during CollectBaseURL, the following exception is thrown:

`Unhandled exception. System.UriFormatException: Invalid URI: The format of the URI could not be determined.
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)
   at System.Uri..ctor(String uriString)
   at libCondeco.CondecoWeb..ctor(String baseUrl) in \...\condeco-cli\libCondeco\CondecoWeb.cs:line 37
   at condeco_cli.Program.BuildCondecoInterface(BaseOptions options, CondecoCliConfig condecoCliConfig) in \...\condeco-cli\condeco-cli\Program.cs:line 469
   at condeco_cli.InteractiveSession.Run() in \...\condeco-cli\condeco-cli\InteractiveSession.cs:line 457        
   at condeco_cli.Program.<>c.<Main>b__2_0(BaseOptions opts) in \...\condeco-cli\condeco-cli\Program.cs:line 46  
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult1 result, Action1 action)
   at condeco_cli.Program.Main(String[] args) in \...\condeco-cli\condeco-cli\Program.cs:line 28`

Adding simple input validation in the CollectBaseURL function. Writing to the config only. No validation reading from the config.

<img width="1249" height="176" alt="image" src="https://github.com/user-attachments/assets/47f7d776-81b5-4c12-ae8f-04e7e35ffd7c" />
