### PR TITLE
Add OCI Container support with automated GitHub Actions publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,27 +67,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.tag.outputs.value }}"
-
-          # List assets for this release and pick the Linux one
-          ASSET_URL=$(gh release view "$TAG" \
-            --repo "${{ github.repository }}" \
-            --json assets \
-            --jq '.assets[] | select(.name | test("condeco-cli-linux-x64"; "i")) | .url')
-
-          if [ -z "$ASSET_URL" ]; then
-            echo "ERROR: No Linux asset found for release $TAG" >&2
-            exit 1
-          fi
+          ASSET_NAME="condeco-cli-linux-x64"
 
           echo "Downloading: $ASSET_URL"
           gh release download "$TAG" \
             --repo "${{ github.repository }}" \
-            --pattern "*linux*" \
+            --pattern "$ASSET_NAME" \
             --dir ./docker-context/
 
           # Rename whatever we downloaded to the fixed name the Dockerfile expects
-          DOWNLOADED=$(ls ./docker-context/)
-          mv "./docker-context/$DOWNLOADED" ./docker-context/condeco-cli
+          mv "./docker-context/$ASSET_NAME" ./docker-context/condeco-cli
           chmod +x ./docker-context/condeco-cli
 
       # -----------------------------------------------------------------------

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,141 @@
+# .github/workflows/docker-publish.yml
+#
+# Triggers:
+#   • Automatically when a new GitHub Release is published (the upstream
+#     release workflow already builds the binaries, so this runs after it).
+#   • Manually via workflow_dispatch for testing / re-builds.
+#
+# What it does:
+#   1. Downloads the Linux binary from the newly-published release assets.
+#   2. Builds a Docker image with that binary embedded.
+#   3. Pushes the image to GitHub Container Registry (ghcr.io) tagged with
+#      both the release version (e.g. v1.6.0) and `latest`.
+
+name: Build & Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build from (e.g. v1.6.0)"
+        required: true
+        default: "latest"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}   # e.g. fiddyschmitt/condeco-cli
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    # Required to push to GHCR and to read release assets
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # -----------------------------------------------------------------------
+      # 1. Checkout (only needed for the Dockerfile)
+      # -----------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # -----------------------------------------------------------------------
+      # 2. Resolve the release tag we want to package
+      #    • On a `release` event   → use the tag that triggered the workflow
+      #    • On `workflow_dispatch` → use the manually supplied input
+      # -----------------------------------------------------------------------
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "value=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # -----------------------------------------------------------------------
+      # 3. Download the Linux binary from the GitHub Release
+      #    The asset is expected to be named  condeco-cli-linux-x64  or similar
+      # -----------------------------------------------------------------------
+      - name: Download Linux binary from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.value }}"
+
+          # List assets for this release and pick the Linux one
+          ASSET_URL=$(gh release view "$TAG" \
+            --repo "${{ github.repository }}" \
+            --json assets \
+            --jq '.assets[] | select(.name | test("condeco-cli-linux-x64"; "i")) | .url')
+
+          if [ -z "$ASSET_URL" ]; then
+            echo "ERROR: No Linux asset found for release $TAG" >&2
+            exit 1
+          fi
+
+          echo "Downloading: $ASSET_URL"
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "*linux*" \
+            --dir ./docker-context/
+
+          # Rename whatever we downloaded to the fixed name the Dockerfile expects
+          DOWNLOADED=$(ls ./docker-context/)
+          mv "./docker-context/$DOWNLOADED" ./docker-context/condeco-cli
+          chmod +x ./docker-context/condeco-cli
+
+      # -----------------------------------------------------------------------
+      # 4. Copy the Dockerfile into the build context
+      # -----------------------------------------------------------------------
+      - name: Prepare Docker build context
+        run: cp Dockerfile docker-context/Dockerfile
+
+      # -----------------------------------------------------------------------
+      # 5. Log in to GHCR
+      # -----------------------------------------------------------------------
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # -----------------------------------------------------------------------
+      # 6. Generate image tags & labels
+      # -----------------------------------------------------------------------
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.tag.outputs.value }}
+            type=raw,value=latest
+
+      # -----------------------------------------------------------------------
+      # 7. Set up Buildx
+      # -----------------------------------------------------------------------
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # -----------------------------------------------------------------------
+      # 8. Build and push
+      # -----------------------------------------------------------------------
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker-context
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Build only for amd64 since the upstream binary targets linux-x64.
+          # Add linux/arm64 if you ever publish an arm64 binary.
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,15 @@
 # ---------------------------------------------------------------------------
 FROM debian:bookworm-slim
 
-# Install ca-certificates so HTTPS calls to the Condeco API work
+# Install:
+# ca-certificates – required for HTTPS calls to the Condeco API
+# libicu72        – required by .NET for globalization (dates, timezones, etc.)
+#                   Bookworm ships ICU 72; update the version suffix if you
+#                   ever rebase onto a newer Debian release.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends \
+         ca-certificates \
+         libicu72 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+# ---------------------------------------------------------------------------
+# condeco-cli – minimal Linux container
+#
+# The image expects a config file to be mounted at runtime:
+#   docker run --rm -v /path/to/condeco-cli.json:/app/condeco-cli.json \
+#              ghcr.io/<owner>/condeco-cli --autobook
+#
+# The binary is a self-contained .NET executable; no .NET runtime is needed
+# inside the image, but glibc *is* required (hence debian-slim, not alpine).
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+
+# Install ca-certificates so HTTPS calls to the Condeco API work
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# The binary is copied in by the GitHub Actions build step (see
+# .github/workflows/docker-publish.yml).
+# It is downloaded from the GitHub Release assets before `docker build`.
+COPY condeco-cli ./condeco-cli
+RUN chmod +x ./condeco-cli
+
+# Default command – override with --checkin or any other flag at `docker run`
+ENTRYPOINT ["/app/condeco-cli"]
+CMD ["--autobook"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,37 @@ To run a Linux cron job, follow [these](https://github.com/fiddyschmitt/condeco-
 
 To run in a Windows Scheduled Task, follow [these](https://github.com/fiddyschmitt/condeco-cli/wiki/Scheduling-in-Windows) instructions.
 
+## Docker
+
+A Docker image is available from [GitHub Container Registry](https://github.com/fiddyschmitt/condeco-cli/pkgs/container/condeco-cli) and is automatically built whenever a new release is published. By default, the docker image runs --autobook but this can be overriden by passing command line arguments.
+
+Pull the latest image:
+
+```bash
+docker pull ghcr.io/fiddyschmitt/condeco-cli:latest
+```
+
+Run autobook with your config file mounted:
+
+```bash
+docker run --rm \
+  -v /path/to/config.ini:/app/config.ini \
+  ghcr.io/fiddyschmitt/condeco-cli:latest
+```
+
+Run checkin with your config file mounted:
+
+```bash
+docker run --rm \
+  -v /path/to/config.ini:/app/config.ini \
+  ghcr.io/fiddyschmitt/condeco-cli:latest --checkin
+```
+
+> **Note:** On SELinux-enabled systems (e.g. Fedora, RHEL), append `:Z` to the volume mount flag to avoid permission errors:
+> `-v path/to/config.ini:/app/config.ini:Z`
+
+To use with a scheduler, add a cron entry on the host that calls `docker run` instead of the bare binary — see the [Scheduling in Linux](https://github.com/fiddyschmitt/condeco-cli/wiki/Scheduling-in-Linux) wiki page for the general approach.
+
 ## Thanks
 
 Thanks to those who bought me a coffee!


### PR DESCRIPTION
Do you love how frequently fiddyschmitt is updating condeco-cli but hate having to manually download/update the software like it's the 1990's?!

This PR adds the ability to run `condeco-cli` as a Docker container, with automated image builds via GitHub Actions.

### Changes

- **`Dockerfile`** – Packages the Linux x64 binary into a minimal `debian:bookworm-slim` image. Includes `libicu72` and `ca-certificates` as the only runtime dependencies.
- **`.github/workflows/docker-publish.yml`** – GitHub Actions workflow that automatically builds and publishes the container image to GitHub Container Registry (GHCR) whenever a new release is published. Can also be triggered manually against any existing release tag.
- **`README.md`** – Added a Docker section documenting how to pull the image and run it with a mounted config file, including a note for SELinux-enabled systems.

### Usage

```bash
docker run --rm \
  -v /path/to/condeco-cli.json:/app/condeco-cli.json \
  ghcr.io/aaronjbrown/condeco-cli:latest --checkin
```

Scheduling is handled externally by calling `docker run` from the host cron or Scheduled Task, consistent with the existing scheduling approach documented in the wiki.