### PR TITLE
Retry transient transport failures so a DNS blip doesn't kill the run

### DIFF
--- a/libCondeco/Web/RateLimitedHttpClientFactory.cs
+++ b/libCondeco/Web/RateLimitedHttpClientFactory.cs
@@ -28,6 +28,9 @@ namespace libCondeco.Web
 
             HttpMessageHandler handler = new RateLimitedHandler(limiter, innerHandler);
 
+            //Retries transient transport failures; outside rate-limiting so each retry re-acquires a permit.
+            handler = new RetryHandler(handler);
+
             //Outermost so its retry re-flows through rate-limiting + logging, and the re-login's own
             //traffic (issued via this same client) passes back through here and is exempted.
             if (reLogin != null)

--- a/libCondeco/Web/RetryHandler.cs
+++ b/libCondeco/Web/RetryHandler.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace libCondeco.Web
+{
+    //Retries transient transport failures (e.g. a container DNS blip: EAI_AGAIN at the 00:01 autobook)
+    //so a single hiccup doesn't kill the run. Only failures before the request is sent are retried.
+    public class RetryHandler : DelegatingHandler
+    {
+        //Socket errors that can only occur while establishing the connection - safe to retry for any method.
+        static readonly SocketError[] ConnectPhaseErrors =
+        [
+            SocketError.HostNotFound,       // EAI_NONAME
+            SocketError.TryAgain,           // EAI_AGAIN
+            SocketError.NoData,
+            SocketError.ConnectionRefused,
+            SocketError.TimedOut,
+            SocketError.NetworkUnreachable,
+            SocketError.HostUnreachable,
+            SocketError.NetworkDown,
+            SocketError.HostDown,
+            SocketError.AddressNotAvailable,
+        ];
+
+        readonly int maxAttempts;
+        readonly TimeSpan baseDelay;
+
+        public RetryHandler(HttpMessageHandler innerHandler, int maxAttempts = 5, TimeSpan? baseDelay = null)
+        {
+            InnerHandler = innerHandler;
+            this.maxAttempts = Math.Max(1, maxAttempts);
+            this.baseDelay = baseDelay ?? TimeSpan.FromSeconds(1);
+        }
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    return base.Send(request, cancellationToken);
+                }
+                catch (Exception ex) when (ShouldRetry(ex, request, attempt, cancellationToken))
+                {
+                    var delay = DelayFor(attempt);
+                    Console.WriteLine($"{DateTime.Now}  Transient network error ({Describe(ex)}). Retry {attempt}/{maxAttempts - 1} in {delay.TotalSeconds:N0}s...");
+                    cancellationToken.WaitHandle.WaitOne(delay);
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    return await base.SendAsync(request, cancellationToken);
+                }
+                catch (Exception ex) when (ShouldRetry(ex, request, attempt, cancellationToken))
+                {
+                    var delay = DelayFor(attempt);
+                    Console.WriteLine($"{DateTime.Now}  Transient network error ({Describe(ex)}). Retry {attempt}/{maxAttempts - 1} in {delay.TotalSeconds:N0}s...");
+                    await Task.Delay(delay, cancellationToken);
+                }
+            }
+        }
+
+        bool ShouldRetry(Exception ex, HttpRequestMessage request, int attempt, CancellationToken cancellationToken)
+        {
+            if (attempt >= maxAttempts || cancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            var socketError = FindSocketError(ex);
+
+            //POST/PUT: only retry connect-phase errors (nothing was sent) so a booking can't be duplicated.
+            if (request.Method != HttpMethod.Get && request.Method != HttpMethod.Head)
+            {
+                return socketError.HasValue && Array.IndexOf(ConnectPhaseErrors, socketError.Value) >= 0;
+            }
+
+            //Idempotent methods: retry any transient transport failure.
+            return ex is HttpRequestException || ex is TimeoutException || socketError.HasValue;
+        }
+
+        //Walk the inner-exception chain for a SocketException.
+        static SocketError? FindSocketError(Exception? ex)
+        {
+            for (; ex != null; ex = ex.InnerException)
+            {
+                if (ex is SocketException se)
+                {
+                    return se.SocketErrorCode;
+                }
+            }
+            return null;
+        }
+
+        //Jittered exponential backoff (1/2/4/8s...) capped at 10s.
+        TimeSpan DelayFor(int attempt)
+        {
+            var seconds = Math.Min(baseDelay.TotalSeconds * Math.Pow(2, attempt - 1), 10);
+            var jitterMs = Random.Shared.Next(0, 250);
+            return TimeSpan.FromSeconds(seconds) + TimeSpan.FromMilliseconds(jitterMs);
+        }
+
+        static string Describe(Exception ex)
+        {
+            var socketError = FindSocketError(ex);
+            return socketError.HasValue ? socketError.Value.ToString() : ex.GetType().Name;
+        }
+    }
+}


### PR DESCRIPTION
What

  Adds a RetryHandler to the HTTP pipeline that retries transient transport failures with a short jittered backoff.

Why

  The scheduled autobook fires at 00:01, and login occasionally died on a transient DNS failure — a single blip killed the whole run because nothing retried a failed connection (ReAuthHandler only handles HTTP 401):

  Login unsuccessful.
  Exception during login: System.AggregateException: One or more errors occurred. (Resource temporarily unavailable (boeing.condecosoftware.com:443))
   ---> System.Net.Http.HttpRequestException: Resource temporarily unavailable (boeing.condecosoftware.com:443)
   ---> System.Net.Sockets.SocketException (11): Resource temporarily unavailable
     at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(...)
     at libCondeco.CondecoWeb.LogIn(String username, String password)
  Terminating.
     
  SocketException (11) at the connect stage is EAI_AGAIN ("temporary failure in name resolution") — the request never reached the server.

 How

  - Retries only transport failures that happen before the request is sent, so it can't double-book: non-idempotent methods (POST/PUT) are retried only for connect-phase socket errors; a completed HTTP response (even 5xx) is never
  retried.
  - Backoff is jittered exponential (1/2/4/8s, capped 10s), up to 5 attempts.
  - Sits inside ReAuthHandler and outside RateLimitedHandler, so each retry re-acquires a rate permit and stays within the 50/sec cap.